### PR TITLE
fix build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flow-typed": "rm -rf ./flow-typed && flow-typed install",
     "flow": "flow",
     "demo": "echo 'Navigate to http://localhost:1337/demo/iframe/index.htm or http://localhost:1337/demo/popup/index.htm' && serve . --port 1337 --silent",
-    "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start",
+    "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/karma/bin/karma start",
     "babel": "babel src/ --out-dir dist/module",
     "webpack": "babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --progress",
     "test": "npm run lint && npm run flow-typed && npm run flow && npm run karma",


### PR DESCRIPTION
The `npm run build` command failed on windows with the error below.

This is a windows pathing issue, solution as described here: https://github.com/jmcriffey/babel-istanbul/issues/70#issuecomment-238753515

```
> xcomponent-demo@1.0.3 karma C:\digipolis\prototypes\zoid-demo
> cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start

C:\digipolis\prototypes\zoid-demo\node_modules\.bin\karma:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
```
